### PR TITLE
make windows.go build only on windows for Go

### DIFF
--- a/windows.go
+++ b/windows.go
@@ -1,3 +1,5 @@
+// +build windows
+
 package config
 
 import (


### PR DESCRIPTION
using the Go +build comment syntax to get the job done. Please review. I've no Windows machine, but have checked that windows.go no longer builds on OSX and Linux.

thanks, /michael
